### PR TITLE
Correctly handle trailing semicolons and more fixtures

### DIFF
--- a/pep8ify/fixes/fix_compound_statements.py
+++ b/pep8ify/fixes/fix_compound_statements.py
@@ -6,6 +6,8 @@ from lib2to3.pygram import python_symbols as symbols
 from lib2to3.pytree import Node, Leaf
 
 
+NL = Leaf(token.NEWLINE, '\n')
+
 class FixCompoundStatements(BaseFix):
     '''
     Compound statements (multiple statements on the same line) are
@@ -56,6 +58,12 @@ class FixCompoundStatements(BaseFix):
     def transform_semi(self, node):
         for child in node.children:
             if child.type == token.SEMI:
+                # If the next sibling is a NL, this is a trailing semicolon;
+                # simply remove it and the NL's prefix
+                if child.next_sibling == NL:
+                    child.remove()
+                    continue
+
                 # Strip any whitespace from the next sibling
                 if (child.next_sibling.prefix != child.next_sibling.prefix.
                     lstrip()):

--- a/pep8ify/fixes/fix_compound_statements.py
+++ b/pep8ify/fixes/fix_compound_statements.py
@@ -9,14 +9,14 @@ from lib2to3.pytree import Node, Leaf
 NL = Leaf(token.NEWLINE, '\n')
 
 class FixCompoundStatements(BaseFix):
-    '''
+    """
     Compound statements (multiple statements on the same line) are
     generally discouraged.
 
     While sometimes it's okay to put an if/for/while with a small body
     on the same line, never do this for multi-clause statements. Also
     avoid folding such long lines!
-    '''
+    """
 
     def match(self, node):
         results = {}
@@ -73,7 +73,7 @@ class FixCompoundStatements(BaseFix):
                 # Replace the semi with a newline
                 old_depth = find_indentation(child)
 
-                child.replace([Leaf(token.NEWLINE, '\n'), Leaf(token.INDENT,
-                    old_depth)])
+                child.replace([Leaf(token.NEWLINE, '\n'),
+                               Leaf(token.INDENT, old_depth)])
                 child.changed()
         return node

--- a/pep8ify/fixes/fix_compound_statements.py
+++ b/pep8ify/fixes/fix_compound_statements.py
@@ -58,18 +58,19 @@ class FixCompoundStatements(BaseFix):
     def transform_semi(self, node):
         for child in node.children:
             if child.type == token.SEMI:
+                next_sibling = child.next_sibling
                 # If the next sibling is a NL, this is a trailing semicolon;
                 # simply remove it and the NL's prefix
-                if child.next_sibling == NL:
+                if next_sibling == NL:
                     child.remove()
                     continue
 
                 # Strip any whitespace from the next sibling
-                if (child.next_sibling.prefix != child.next_sibling.prefix.
-                    lstrip()):
-                    child.next_sibling.prefix = (child.next_sibling.prefix.
-                        lstrip())
-                    child.next_sibling.changed()
+                prefix = next_sibling.prefix
+                stripped_prefix = prefix.lstrip()
+                if prefix != stripped_prefix:
+                    next_sibling.prefix = stripped_prefix
+                    next_sibling.changed()
                 # Replace the semi with a newline
                 old_depth = find_indentation(child)
 

--- a/tests/fixtures/compound_statements/compound_statements3_in.py
+++ b/tests/fixtures/compound_statements/compound_statements3_in.py
@@ -1,0 +1,11 @@
+
+do_it() ;
+
+def x():
+    do_it() ;
+    dont_do_it()
+
+def y():
+    do_it() ;
+    # comment
+    dont_do_it()

--- a/tests/fixtures/compound_statements/compound_statements3_out.py
+++ b/tests/fixtures/compound_statements/compound_statements3_out.py
@@ -1,0 +1,13 @@
+
+do_it()
+
+
+def x():
+    do_it()
+    dont_do_it()
+
+
+def y():
+    do_it()
+    # comment
+    dont_do_it()

--- a/tests/fixtures/imports_on_separate_lines/imports_on_separate_lines3_in.py
+++ b/tests/fixtures/imports_on_separate_lines/imports_on_separate_lines3_in.py
@@ -6,3 +6,8 @@ class the_class():
     # some comment
     """ doc string """
     import os, sys
+
+
+class second_class():
+    some_statement
+    import os, sys

--- a/tests/fixtures/imports_on_separate_lines/imports_on_separate_lines3_out.py
+++ b/tests/fixtures/imports_on_separate_lines/imports_on_separate_lines3_out.py
@@ -9,3 +9,9 @@ class the_class():
     """ doc string """
     import os
     import sys
+
+
+class second_class():
+    some_statement
+    import os
+    import sys


### PR DESCRIPTION
Up to this change a trailing semicolon created a superfluous newline, while the semicolon should just have been removed. This is how it is done now.
